### PR TITLE
Use `x-reduct-error` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for labels and content type, [PR-50](https://github.com/reductstore/reduct-cpp/pull/50)
+- Use `x-reduct-error` header for error responses, [PR-51](https://github.com/reductstore/reduct-cpp/pull/51)
 
 ## [1.2.0] - 2022-12-20
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Since v1.0 ReductStore provides the error message in `x-reduct-error` header, it can be used in HEAD requests. 
However, the SDK uses  the JSON body,

### What is the new behavior?

The SDK uses the header.

### Does this PR introduce a breaking change?

No

### Other information:
