### PR TITLE
Implement continuous querying

### DIFF
--- a/.github/actions/check-package/action.yml
+++ b/.github/actions/check-package/action.yml
@@ -16,6 +16,9 @@ runs:
         cd examples/build
         cmake ..
         cmake --build .
+    - name: Run ReductStore
+      shell: bash
+      run: docker run -p 8383:8383 -v ${PWD}/data:/data  -d reduct/store:main
     - name: Run examples
       shell: bash
       run: |

--- a/.github/actions/check-package/action.yml
+++ b/.github/actions/check-package/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Run examples
       shell: bash
       run: |
-        run: docker run -p 8383:8383 -d reduct/store:main
+        docker run -p 8383:8383 -d reduct/store:main
         cd examples/build
         ./usage-example
         ./subscription

--- a/.github/actions/check-package/action.yml
+++ b/.github/actions/check-package/action.yml
@@ -20,6 +20,7 @@ runs:
       shell: bash
       run: |
         docker run -p 8383:8383 -d reduct/store:main
+        sleep 3
         cd examples/build
         ./usage-example
         ./subscription

--- a/.github/actions/check-package/action.yml
+++ b/.github/actions/check-package/action.yml
@@ -16,12 +16,10 @@ runs:
         cd examples/build
         cmake ..
         cmake --build .
-    - name: Run ReductStore
-      shell: bash
-      run: docker run -p 8383:8383 -v ${PWD}/data:/data  -d reduct/store:main
     - name: Run examples
       shell: bash
       run: |
+        run: docker run -p 8383:8383 -d reduct/store:main
         cd examples/build
         ./usage-example
         ./subscription

--- a/.github/actions/check-package/action.yml
+++ b/.github/actions/check-package/action.yml
@@ -16,3 +16,9 @@ runs:
         cd examples/build
         cmake ..
         cmake --build .
+    - name: Run examples
+      shell: bash
+      run: |
+        cd examples/build
+        ./usage-example
+        ./subscription

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Implement continuous querying, [PR-53](https://github.com/reductstore/reduct-cpp/pull/53)
+
 ### Update
 
 - Adapt to the new API v1.4, [PR-52](https://github.com/reductstore/reduct-cpp/pull/52)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ project(reductcpp VERSION ${REDUCT_CPP_FULL_VERSION})
 message(STATUS "Version ${REDUCT_CPP_FULL_VERSION}")
 
 set(REDUCT_CPP_ENABLE_TESTS OFF CACHE BOOL "Compile tests")
-set(REDUCT_CPP_ENABLE_EXAMPLES OFF CACHE BOOL "Compile examples")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -25,3 +24,4 @@ add_subdirectory(src)
 if (REDUCT_CPP_ENABLE_TESTS)
     add_subdirectory(tests)
 endif ()
+

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.18)
 project(ReductCppExamples)
 set(CMAKE_CXX_STANDARD 20)
 
-
-find_package(ReductCpp 1.4.0)
 find_package(ZLIB)
 find_package(OpenSSL)
 
+
+
+find_package(ReductCpp 1.4.0)
+
 add_executable(usage-example usage_example.cc)
+add_executable(subscription subscription.cc)
 target_link_libraries(usage-example ${REDUCT_CPP_LIBRARIES} ${ZLIB_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(subscription ${REDUCT_CPP_LIBRARIES} ${ZLIB_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto)
+

--- a/examples/subscription.cc
+++ b/examples/subscription.cc
@@ -47,15 +47,21 @@ int main() {
   };
 
   // Continuously read messages until we get 3 good ones
-  bucket->Query("entry-1", IBucket::Time::clock::now(), std::nullopt, opts, [&good_count](auto &&record) {
-    auto [msg, read_err] = record.ReadAll();
-    if (read_err) {
-      std::cerr << "Error: " << read_err;
-      return false;
-    }
-    std::cout << "Read: " << msg << std::endl;
-    return ++good_count != 3;
-  });
+  auto query_err =
+      bucket->Query("entry-1", IBucket::Time::clock::now(), std::nullopt, opts, [&good_count](auto &&record) {
+        auto [msg, read_err] = record.ReadAll();
+        if (read_err) {
+          std::cerr << "Error: " << read_err;
+          return false;
+        }
+        std::cout << "Read: " << msg << std::endl;
+        return ++good_count != 3;
+      });
 
   writer.join();
+
+  if (query_err) {
+    std::cerr << "Query error:" << query_err;
+    return -1;
+  }
 }

--- a/examples/subscription.cc
+++ b/examples/subscription.cc
@@ -1,0 +1,63 @@
+// Copyright 2023 Alexey Timin
+
+#include <reduct/client.h>
+#include <thread>
+#include <iostream>
+
+using reduct::IClient;
+using reduct::IBucket;
+
+int main() {
+    auto writer = std::thread([]() {
+        auto client = IClient::Build("http://127.0.0.1:8383");
+
+        auto [bucket, err] = client->GetOrCreateBucket("bucket");
+        if (err) {
+            std::cerr << "Error: " << err;
+            return;
+        }
+
+        for (int i = 0; i < 10; ++i) {
+            const IBucket::WriteOptions opts{
+                    .timestamp = IBucket::Time::clock::now(),
+                    .labels = {{"good", i % 2 == 0 ? "true" : "false"},},
+            };
+
+            const auto msg = "Hey " + std::to_string(i);
+            [[maybe_unused]] auto write_err = bucket->Write("entry-1", opts,
+                                                            [msg](auto rec) {
+                                                                rec->WriteAll(msg);
+                                                            });
+            std::cout << "Write: " << msg << std::endl;
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    });
+
+    // Subscribe to good messages
+    int good_count = 0;
+    auto client = IClient::Build("http://127.0.0.1:8383");
+    auto [bucket, err] = client->GetOrCreateBucket("bucket");
+    if (err) {
+        std::cerr << "Error: " << err;
+        return -1;
+    }
+
+    const auto opts = IBucket::QueryOptions{
+            .include = {{"good", "true"}},
+            .continuous = true,
+            .poll_interval = std::chrono::milliseconds{100},
+    };
+
+    // Continuously read messages until we get 3 good ones
+    bucket->Query("entry-1", IBucket::Time::clock::now(), std::nullopt, opts, [&good_count](auto &&record) {
+        auto [msg, read_err] = record.ReadAll();
+        if (read_err) {
+            std::cerr << "Error: " << read_err;
+            return false;
+        }
+        std::cout << "Read: " << msg << std::endl;
+        return ++good_count != 3;
+    });
+
+    writer.join();
+}

--- a/examples/subscription.cc
+++ b/examples/subscription.cc
@@ -1,63 +1,61 @@
 // Copyright 2023 Alexey Timin
 
 #include <reduct/client.h>
-#include <thread>
-#include <iostream>
 
-using reduct::IClient;
+#include <iostream>
+#include <thread>
+
 using reduct::IBucket;
+using reduct::IClient;
 
 int main() {
-    auto writer = std::thread([]() {
-        auto client = IClient::Build("http://127.0.0.1:8383");
-
-        auto [bucket, err] = client->GetOrCreateBucket("bucket");
-        if (err) {
-            std::cerr << "Error: " << err;
-            return;
-        }
-
-        for (int i = 0; i < 10; ++i) {
-            const IBucket::WriteOptions opts{
-                    .timestamp = IBucket::Time::clock::now(),
-                    .labels = {{"good", i % 2 == 0 ? "true" : "false"},},
-            };
-
-            const auto msg = "Hey " + std::to_string(i);
-            [[maybe_unused]] auto write_err = bucket->Write("entry-1", opts,
-                                                            [msg](auto rec) {
-                                                                rec->WriteAll(msg);
-                                                            });
-            std::cout << "Write: " << msg << std::endl;
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
-    });
-
-    // Subscribe to good messages
-    int good_count = 0;
+  auto writer = std::thread([]() {
     auto client = IClient::Build("http://127.0.0.1:8383");
+
     auto [bucket, err] = client->GetOrCreateBucket("bucket");
     if (err) {
-        std::cerr << "Error: " << err;
-        return -1;
+      std::cerr << "Error: " << err;
+      return;
     }
 
-    const auto opts = IBucket::QueryOptions{
-            .include = {{"good", "true"}},
-            .continuous = true,
-            .poll_interval = std::chrono::milliseconds{100},
-    };
+    for (int i = 0; i < 10; ++i) {
+      const IBucket::WriteOptions opts{
+          .timestamp = IBucket::Time::clock::now(),
+          .labels = {{"good", i % 2 == 0 ? "true" : "false"}},
+      };
 
-    // Continuously read messages until we get 3 good ones
-    bucket->Query("entry-1", IBucket::Time::clock::now(), std::nullopt, opts, [&good_count](auto &&record) {
-        auto [msg, read_err] = record.ReadAll();
-        if (read_err) {
-            std::cerr << "Error: " << read_err;
-            return false;
-        }
-        std::cout << "Read: " << msg << std::endl;
-        return ++good_count != 3;
-    });
+      const auto msg = "Hey " + std::to_string(i);
+      [[maybe_unused]] auto write_err = bucket->Write("entry-1", opts, [msg](auto rec) { rec->WriteAll(msg); });
+      std::cout << "Write: " << msg << std::endl;
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+  });
 
-    writer.join();
+  // Subscribe to good messages
+  int good_count = 0;
+  auto client = IClient::Build("http://127.0.0.1:8383");
+  auto [bucket, err] = client->GetOrCreateBucket("bucket");
+  if (err) {
+    std::cerr << "Error: " << err;
+    return -1;
+  }
+
+  const auto opts = IBucket::QueryOptions{
+      .include = {{"good", "true"}},
+      .continuous = true,
+      .poll_interval = std::chrono::milliseconds{100},
+  };
+
+  // Continuously read messages until we get 3 good ones
+  bucket->Query("entry-1", IBucket::Time::clock::now(), std::nullopt, opts, [&good_count](auto &&record) {
+    auto [msg, read_err] = record.ReadAll();
+    if (read_err) {
+      std::cerr << "Error: " << read_err;
+      return false;
+    }
+    std::cout << "Read: " << msg << std::endl;
+    return ++good_count != 3;
+  });
+
+  writer.join();
 }

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -191,7 +191,7 @@ class IBucket {
    * Query options
    */
   struct QueryOptions {
-    std::optional<std::chrono::milliseconds> ttl; ///< time to live
+    std::optional<std::chrono::milliseconds> ttl;    ///< time to live
     LabelMap include;   ///< include labels
     LabelMap exclude;   ///< exclude labels
     bool continuous;    ///< continuous query. If true, the method returns the latest record and waits for the next one

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -77,7 +77,7 @@ class IBucket {
   struct ReadableRecord {
     Time timestamp;
     size_t size;
-    bool last;
+    [[deprecated]] bool last;  //< @deprecated, unreliable flag
     LabelMap labels;
     std::string content_type;
 
@@ -187,10 +187,15 @@ class IBucket {
   virtual Error Write(std::string_view entry_name, const WriteOptions& options,
                       WriteRecordCallback callback) const noexcept = 0;
 
+  /**
+   * Query options
+   */
   struct QueryOptions {
-    std::optional<std::chrono::milliseconds> ttl;
-    LabelMap include;
-    LabelMap exclude;
+    std::optional<std::chrono::milliseconds> ttl; ///< time to live
+    LabelMap include;   ///< include labels
+    LabelMap exclude;   ///< exclude labels
+    bool continuous;    ///< continuous query. If true, the method returns the latest record and waits for the next one
+    std::chrono::milliseconds poll_interval;  ///< poll interval for continuous query
   };
 
   /**

--- a/tests/reduct/entry_api_test.cc
+++ b/tests/reduct/entry_api_test.cc
@@ -37,7 +37,6 @@ TEST_CASE("reduct::IBucket should write/read a record", "[entry_api]") {
     REQUIRE(record.timestamp == ts);
     REQUIRE(record.labels == std::map<std::string, std::string>{{"label1", "value1"}, {"label2", "value2"}});
     REQUIRE(record.content_type == "text/plain");
-    REQUIRE(record.last);
 
     auto [data, read_err] = record.ReadAll();
     received_data = std::move(data);
@@ -68,7 +67,6 @@ TEST_CASE("reduct::IBucket should read the latest record", "[entry_api]") {
   auto err = bucket->Read("entry", {}, [ts](auto record) {
     REQUIRE(record.size == 10);
     REQUIRE(record.timestamp == ts + us(2));
-    REQUIRE(record.last);
 
     return true;
   });
@@ -181,7 +179,6 @@ TEST_CASE("reduct::IBucket should query records", "[entry_api]") {
     auto err = bucket->Query("entry", ts, ts + us(1), {}, [ts](auto record) {
       REQUIRE(record.timestamp == ts);
       REQUIRE(record.size == 10);
-      REQUIRE(record.last);
       return true;
     });
 
@@ -197,7 +194,6 @@ TEST_CASE("reduct::IBucket should query records", "[entry_api]") {
                                });
 
                                REQUIRE(read_err == Error::kOk);
-                               REQUIRE(record.last);
                                return true;
                              });
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Since version 1.4, ReductStore supports continuous queering. We need this in the C++ SDK.

### What is the new behavior?

I added the `continuous` option to `IBucket::QueryOption` and implement additional logic, so that the client waits for new records.  Instead of tests, I added an example.

### Does this PR introduce a breaking change?

No

### Other information:
