### PR TITLE
Support for batched records

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -9,12 +9,16 @@ inputs:
     description: 'Tags for tests'
     required: false
     default: ""
+  reductstore-version: # id of input
+    description: 'Reduct Store version'
+    required: false
+    default: "main"
 runs:
   using: "composite"
   steps:
     - name: Run Reduct Store
       shell: bash
-      run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{inputs.api-token}} -d reduct/store:main
+      run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{inputs.api-token}} -d reduct/store:${{inputs.reductstore-version}}
 
     - name: Load image with tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
     strategy:
       matrix:
         token: [ "", "TOKEN" ]
+        reductstore_version: [ "main", "latest" ]
         include:
           - token: ""
             tags: "~[token_api]"
@@ -81,3 +82,4 @@ jobs:
         with:
           api-token: ${{matrix.token}}
           tags: ${{matrix.tags}}
+          reductstore-version: ${{matrix.reductstore_version}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for batched records, [PR-54](https://github.com/reductstore/reduct-cpp/pull/54)
+
 ## [1.4.0] - 2023-06-04
 
 ### Added

--- a/src/reduct/bucket.cc
+++ b/src/reduct/bucket.cc
@@ -274,6 +274,7 @@ class Bucket : public IBucket {
     record.timestamp = FromMicroseconds(headers["x-reduct-time"]);
     record.size = std::stoi(headers["content-length"]);
     record.content_type = headers["content-type"];
+    record.last = headers["x-reduct-last"] == "1";
 
     for (const auto& [key, value] : headers) {
       if (key.starts_with("x-reduct-label-")) {
@@ -362,7 +363,7 @@ class Bucket : public IBucket {
     size_t total_records = std::count_if(headers.begin(), headers.end(),
                                          [](const auto& header) { return header.first.starts_with("x-reduct-time-"); });
 
-    std::map<std::string , std::string> ordered_headers(headers.begin(), headers.end());
+    std::map<std::string, std::string> ordered_headers(headers.begin(), headers.end());
     for (auto header = ordered_headers.begin(); header != ordered_headers.end(); ++header) {
       if (!header->first.starts_with("x-reduct-time-")) {
         continue;

--- a/src/reduct/bucket.cc
+++ b/src/reduct/bucket.cc
@@ -362,7 +362,8 @@ class Bucket : public IBucket {
     size_t total_records = std::count_if(headers.begin(), headers.end(),
                                          [](const auto& header) { return header.first.starts_with("x-reduct-time-"); });
 
-    for (auto header = headers.begin(); header != headers.end(); ++header) {
+    std::map<std::string , std::string> ordered_headers(headers.begin(), headers.end());
+    for (auto header = ordered_headers.begin(); header != ordered_headers.end(); ++header) {
       if (!header->first.starts_with("x-reduct-time-")) {
         continue;
       }

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -77,7 +77,7 @@ class IBucket {
   struct ReadableRecord {
     Time timestamp;
     size_t size;
-    [[deprecated]] bool last;  //< @deprecated, unreliable flag
+    bool last;
     LabelMap labels;
     std::string content_type;
 

--- a/src/reduct/internal/http_client.h
+++ b/src/reduct/internal/http_client.h
@@ -42,6 +42,8 @@ class IHttpClient {
 
   virtual Error Delete(std::string_view path) const noexcept = 0;
 
+  [[nodiscard]] virtual std::string_view api_version() const noexcept = 0;
+
   static std::unique_ptr<IHttpClient> Build(std::string_view url, const HttpOptions &options);
 };
 


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

Since version 1.5, ReductStore supports batched records in an HTTP body. The SDK doesn't implement it.

### What is the new behavior?

I've implemented an API version check. If it is equal or higher than 1.5, the SDK uses the batched records for quering.

### Does this PR introduce a breaking change?

No

### Other information:
