### PR TITLE
Add an option to read only metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for batched records, [PR-54](https://github.com/reductstore/reduct-cpp/pull/54)
+- Option to read only metadata of a record, [PR-55](https://github.com/reductstore/reduct-cpp/pull/55)
 
 ## [1.4.0] - 2023-06-04
 

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -152,12 +152,21 @@ class IBucket {
    * Read a record in chunks
    * @param entry_name entry in bucket
    * @param ts timestamp, if it is nullopt, the method returns the latest record
-   * @param callback called with calback. To continue receiving it should return true
+   * @param callback called with callback. To continue receiving it should return true
    * @return HTTP or communication error
    */
   virtual Error Read(std::string_view entry_name, std::optional<Time> ts,
                      ReadRecordCallback callback) const noexcept = 0;
 
+  /**
+   * Read only metadata of a record
+   * @param entry_name entry in bucket
+   * @param ts timestamp, if it is nullopt, the method returns the latest record
+   * @param callback called with callback. To continue receiving it should return true
+   * @return HTTP or communication error
+   */
+  virtual Error Head(std::string_view entry_name, std::optional<Time> ts,
+                     ReadRecordCallback callback) const noexcept = 0;
   /**
    * Write a record
    * @param entry_name entry in bucket
@@ -196,6 +205,7 @@ class IBucket {
     LabelMap exclude;   ///< exclude labels
     bool continuous;    ///< continuous query. If true, the method returns the latest record and waits for the next one
     std::chrono::milliseconds poll_interval;  ///< poll interval for continuous query
+    bool head_only;     ///< read only metadata
   };
 
   /**

--- a/src/reduct/client.cc
+++ b/src/reduct/client.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Alexey Timin
+// Copyright 2022-2023 Alexey Timin
 
 #include "reduct/client.h"
 
@@ -78,7 +78,7 @@ class Client : public IClient {
   }
 
   [[nodiscard]] UPtrResult<IBucket> GetBucket(std::string_view name) const noexcept override {
-    auto err = client_->Head(fmt::format("/b/{}", name));
+    auto [_, err] = client_->Head(fmt::format("/b/{}", name));
     if (err) {
       if (err.code == 404) {
         err.message = fmt::format("Bucket '{}' is not found", name);

--- a/src/reduct/internal/http_client.h
+++ b/src/reduct/internal/http_client.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Alexey Timin
+// Copyright 2022-2023 Alexey Timin
 
 #ifndef REDUCT_CPP_HTTP_CLIENT_H
 #define REDUCT_CPP_HTTP_CLIENT_H
@@ -25,7 +25,7 @@ class IHttpClient {
 
   virtual Error Get(std::string_view path, ResponseCallback, ReadCallback) const noexcept = 0;
 
-  virtual Error Head(std::string_view path) const noexcept = 0;
+  virtual Result<Headers> Head(std::string_view path) const noexcept = 0;
 
   virtual Error Post(std::string_view path, std::string_view body,
                      std::string_view mime = "application/json") const noexcept = 0;

--- a/tests/reduct/entry_api_test.cc
+++ b/tests/reduct/entry_api_test.cc
@@ -129,6 +129,9 @@ TEST_CASE("reduct::IBucket should write a record in chunks", "[entry_api]") {
 }
 
 TEST_CASE("reduct::IBucket should query records", "[entry_api]") {
+  auto [head, content] = GENERATE(std::make_tuple(false, "some_data1some_data2some_data3"), std::make_tuple(true, ""));
+  CAPTURE(head);
+
   Fixture ctx;
   auto [bucket, _] = ctx.client->CreateBucket(kBucketName);
   REQUIRE(bucket);
@@ -146,7 +149,7 @@ TEST_CASE("reduct::IBucket should query records", "[entry_api]") {
 
   std::string all_data;
   SECTION("receive all data") {
-    auto err = bucket->Query("entry", ts, ts + us(3), {}, [&all_data](auto record) {
+    auto err = bucket->Query("entry", ts, ts + us(3), {.head_only = head}, [&all_data](auto record) {
       auto read_err = record.Read([&all_data](auto data) {
         all_data.append(data);
         return true;
@@ -157,7 +160,7 @@ TEST_CASE("reduct::IBucket should query records", "[entry_api]") {
     });
 
     REQUIRE(err == Error::kOk);
-    REQUIRE(all_data == "some_data1some_data2some_data3");
+    REQUIRE(all_data == content);
   }
 
   SECTION("stop receiving") {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md have been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

ReductStore v1.5 supports for HEAD endpoints to read only metadata about records without the content. The C++ SDK doesn't support it.


### What is the new behavior?

I've added the option to the `Bucker.Query` and `Bucker.Head` methods.

### Does this PR introduce a breaking change?

No

### Other information:
