### PR TITLE
Add limit option to query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `IBucket.RemoveEntry` to remove entry from bucket, [PR-57](https://github.com/reductstore/reduct-cpp/pull/57)
+- `QueryOption.limit` to limit the number of records returned by a query, [PR-58](https://github.com/reductstore/reduct-cpp/pull/58)
 
 ## [1.5.0] - 2023-06-30
 

--- a/src/reduct/bucket.cc
+++ b/src/reduct/bucket.cc
@@ -184,6 +184,10 @@ class Bucket : public IBucket {
       url += "continuous=true&";
     }
 
+    if (options.limit) {
+      url += fmt::format("limit={}&", *options.limit);
+    }
+
     for (const auto& [key, value] : options.include) {
       url += fmt::format("&include-{}={}", key, value);
     }

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -206,6 +206,7 @@ class IBucket {
     bool continuous;    ///< continuous query. If true, the method returns the latest record and waits for the next one
     std::chrono::milliseconds poll_interval;  ///< poll interval for continuous query
     bool head_only;     ///< read only metadata
+    std::optional<size_t> limit;  ///< limit number of records
   };
 
   /**

--- a/tests/reduct/entry_api_test.cc
+++ b/tests/reduct/entry_api_test.cc
@@ -250,3 +250,28 @@ TEST_CASE("reduct::IBucket should query records (huge blobs)", "[entry_api]") {
   REQUIRE(received_data[0] == blob1);
   REQUIRE(received_data[1] == blob2);
 }
+
+TEST_CASE("reduct::IBucket should limit records in a query", "[entry_api][1_6]") {
+  Fixture ctx;
+  auto [bucket, _] = ctx.client->GetBucket("bucket_1");
+  REQUIRE(bucket);
+
+  int count;
+  auto err =
+      bucket->Query("entry-1", IBucket::Time{}, IBucket::Time::clock::now(), {.limit = 1}, [&count](auto record) {
+        count++;
+        return true;
+      });
+
+  REQUIRE(err == Error::kOk);
+  REQUIRE(count == 1);
+
+  count = 0;
+  err = bucket->Query("entry-1", IBucket::Time{}, IBucket::Time::clock::now(), {.limit = 2}, [&count](auto record) {
+    count++;
+    return true;
+  });
+
+  REQUIRE(err == Error::kOk);
+  REQUIRE(count == 2);
+}


### PR DESCRIPTION
Closes #56 

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Feature

### What is the current behavior?

See #56 

### What is the new behavior?

A use can limit the number of records in a query by using the `QueryOptions.limit` option.

### Does this PR introduce a breaking change?

No

### Other information:
