### PR TITLE
RS-68: Fix writing blobs bigger than 512Kb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Fixed:
+
+- RS-68: Fix writing blobs bigger than 512Kb, [PR-62](https://github.com/reductstore/reduct-cpp/pull/62)
+
 ### [1.7.0] - 2023-10-06
 
 ### Added

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -143,7 +143,7 @@ class IBucket {
     void WriteAll(std::string data) {
       content_length_ = data.size();
       callback_ = [data = std::move(data)](size_t offset, size_t size) {
-        return std::pair{data.size() <= offset + size, data.substr(offset, size)};
+        return std::pair{true, data.substr(offset, size)};
       };
     }
   };

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -208,7 +208,7 @@ class IBucket {
   /**
    * Write a record
    * @param entry_name entry in bucket
-   * @param ts timestamp, if it is nullopt, the method returns the latest record
+   * @param ts timestamp, if it is nullopt, the method will use current time
    * @param callback
    * @return HTTP or communication error
    */

--- a/src/reduct/internal/http_client.cc
+++ b/src/reduct/internal/http_client.cc
@@ -13,7 +13,7 @@ namespace reduct::internal {
 
 using httplib::DataSink;
 
-constexpr size_t kMaxChunkSize = 1'000'000;
+constexpr size_t kMaxChunkSize = 512'000;
 
 class HttpClient : public IHttpClient {
  public:

--- a/tests/reduct/entry_api_test.cc
+++ b/tests/reduct/entry_api_test.cc
@@ -83,7 +83,7 @@ TEST_CASE("reduct::IBucket should read a record in chunks", "[entry_api]") {
   REQUIRE(bucket);
 
   IBucket::Time ts = IBucket::Time::clock::now();
-  const std::string blob(10'000, 'x');
+  const std::string blob(10'000'000, 'x');
   REQUIRE(bucket->Write("entry", ts, [&blob](auto rec) { rec->WriteAll(blob); }) == Error::kOk);
 
   std::string received;
@@ -108,7 +108,7 @@ TEST_CASE("reduct::IBucket should write a record in chunks", "[entry_api]") {
   REQUIRE(bucket);
 
   IBucket::Time ts = IBucket::Time::clock::now();
-  const std::string blob(10'000, 'x');
+  const std::string blob(10'000'000, 'x');
   REQUIRE(bucket->Write("entry", ts, [&blob](auto rec) {
     rec->Write(blob.size(), [&](auto offset, auto size) {
       return std::pair{


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)


### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

When a written blob is bigger than one transmission chunk, the SDK stops sending data because of a wrong result in the writing callback.

### What is the new behavior?

The flag was fixed and I added improved the tests to cover this case.

### Does this PR introduce a breaking change?

No

### Other information:
