### PR TITLE
Update documentation link to new website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed:
+
+- docs: update link to new website, [PR-63](https://github.com/reductstore/reduct-cpp/pull/63)
+
 ### [1.7.1] - 2023-11-04
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ find_package(ReductCpp)
 ## References
 
 * [Documentation](https://cpp.reduct.store)
-* [ReductStore HTTP API](https://docs.reduct.store/http-api)
+* [ReductStore HTTP API](https://reduct.store/docs/http-api)

--- a/docs/api_reference/index.md
+++ b/docs/api_reference/index.md
@@ -1,7 +1,7 @@
 # 📒 API Reference
 
 The API reference for the SDK provides information on how to communicate
-with [ReductStore via HTTP]((https://docs.reduct.store). The SDK is designed
+with [ReductStore via HTTP]((https://reduct.store/docs). The SDK is designed
 to hide implementation details in .cc files, allowing users to work with abstract interfaces and factory methods.
 
 ## Error Handling

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -71,5 +71,5 @@ You can then run the example with the following command:
 ## Next Steps
 
 You can find more detailed documentation and examples in [the Reference API section](docs/api_reference/). You can also
-refer to the [ReductStore HTTP API](https://docs.reduct.store/http-api) documentation for a complete reference
+refer to the [ReductStore HTTP API](https://reduct.store/docs/http-api) documentation for a complete reference
 of the available API calls.

--- a/tests/reduct/bucket_api_test.cc
+++ b/tests/reduct/bucket_api_test.cc
@@ -122,7 +122,7 @@ TEST_CASE("reduct::IBucket should get bucket stats", "[bucket_api]") {
   REQUIRE(info == IBucket::BucketInfo{
                       .name = kBucketName,
                       .entry_count = 2,
-                      .size = 18,
+                      .size = 80,
                       .oldest_record = t,
                       .latest_record = t + std::chrono::seconds(1),
                       .is_provisioned = false,
@@ -141,7 +141,7 @@ TEST_CASE("reduct::IBucket should get list of entries", "[bucket_api]") {
                             .name = "entry-1",
                             .record_count = 2,
                             .block_count = 1,
-                            .size = 12,
+                            .size = 78,
                             .oldest_record = t + s(1),
                             .latest_record = t + s(2),
                         });
@@ -150,7 +150,7 @@ TEST_CASE("reduct::IBucket should get list of entries", "[bucket_api]") {
                             .name = "entry-2",
                             .record_count = 2,
                             .block_count = 1,
-                            .size = 12,
+                            .size = 78,
                             .oldest_record = t + s(3),
                             .latest_record = t + s(4),
                         });

--- a/tests/reduct/server_api_test.cc
+++ b/tests/reduct/server_api_test.cc
@@ -22,7 +22,7 @@ TEST_CASE("reduct::Client should get info", "[server_api]") {
   REQUIRE(info.version >= "1.2.0");
 
   REQUIRE(info.bucket_count == 2);
-  REQUIRE(info.usage == 36);
+  REQUIRE(info.usage == 234);
   REQUIRE(info.uptime.count() >= 1);
   REQUIRE(info.oldest_record.time_since_epoch() == s(1));
   REQUIRE(info.latest_record.time_since_epoch() == s(6));
@@ -39,13 +39,13 @@ TEST_CASE("reduct::Client should list buckets", "[server_api]") {
 
   REQUIRE_FALSE(list.empty());
   REQUIRE(list[0].name == "bucket_1");
-  REQUIRE(list[0].size == 24);
+  REQUIRE(list[0].size == 156);
   REQUIRE(list[0].entry_count == 2);
   REQUIRE(list[0].oldest_record.time_since_epoch() == s(1));
   REQUIRE(list[0].latest_record.time_since_epoch() == s(4));
 
   REQUIRE(list[1].name == "bucket_2");
-  REQUIRE(list[1].size == 12);
+  REQUIRE(list[1].size == 78);
   REQUIRE(list[1].entry_count == 1);
   REQUIRE(list[1].oldest_record.time_since_epoch() == s(5));
   REQUIRE(list[1].latest_record.time_since_epoch() == s(6));


### PR DESCRIPTION
With new website we need to change links from docs.reduct.store to reduct.store/docs