### PR TITLE
RS-179: add license information to `ServerInfo`

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: docker run -p 8383:8383 -v ${PWD}:/workdir
         --env RS_API_TOKEN=${{inputs.api-token}}
-        --env RS_LICENSE_FILE=${{inputs.lic_file}}
+        --env RS_LICENSE_FILE=/workdir/${{inputs.lic_file}}
         -d reduct/store:${{inputs.reductstore-version}}
 
     - name: Load image with tests

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -15,8 +15,7 @@ inputs:
     default: "main"
   lic_file: # id of input
     description: 'License file'
-    required: false
-    default: "lic.key"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -24,7 +23,7 @@ runs:
       shell: bash
       run: docker run -p 8383:8383 -v ${PWD}:/workdir
         --env RS_API_TOKEN=${{inputs.api-token}}
-        --env RS_LICENSE_FILE=/workdir/${{inputs.lic_file}}
+        --env RS_LICENSE_PATH=/workdir/${{inputs.lic_file}}
         -d reduct/store:${{inputs.reductstore-version}}
 
     - name: Load image with tests

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -20,10 +20,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Generate license
-      shell: bash
-      run: echo '${{secrets.LICENSE_KEY}}' > lic.key
-
     - name: Run Reduct Store
       shell: bash
       run: docker run -p 8383:8383 -v ${PWD}:/workdir

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -13,12 +13,23 @@ inputs:
     description: 'Reduct Store version'
     required: false
     default: "main"
+  lic_file: # id of input
+    description: 'License file'
+    required: false
+    default: "lic.key"
 runs:
   using: "composite"
   steps:
+    - name: Generate license
+      shell: bash
+      run: echo '${{secrets.LICENSE_KEY}}' > lic.key
+
     - name: Run Reduct Store
       shell: bash
-      run: docker run -p 8383:8383 -v ${PWD}/data:/data --env RS_API_TOKEN=${{inputs.api-token}} -d reduct/store:${{inputs.reductstore-version}}
+      run: docker run -p 8383:8383 -v ${PWD}:/workdir
+        --env RS_API_TOKEN=${{inputs.api-token}}
+        --env RS_LICENSE_FILE=${{inputs.lic_file}}
+        -d reduct/store:${{inputs.reductstore-version}}
 
     - name: Load image with tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build cpplint image
         run: pip install cpplint
       - name: Check code in /src
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cpplint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and export
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: cpplint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install conan
         run: pip3 install conan==1.58.0
       - uses: ./.github/actions/check-package
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: cpplint
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/check-package
 
   tests:
@@ -69,8 +69,8 @@ jobs:
             exclude_token_api_tag: ""
           - reductstore_version: "main"
             exclude_api_version_tag: ""
-          - reductstore_version: "latest"
-            exclude_api_version_tag: "~[1_9]"
+#          - reductstore_version: "latest"
+#            exclude_api_version_tag: "~[1_9]"
           - license_file: ""
             exclude_license_tag: "~[license]"
 
@@ -85,7 +85,7 @@ jobs:
         with:
           name: image
           path: /tmp/
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Generate license
         run: echo '${{secrets.LICENSE_KEY}}' > lic.key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build cpplint image
         run: pip install cpplint
       - name: Check code in /src
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cpplint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and export
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: cpplint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install conan
         run: pip3 install conan==1.58.0
       - uses: ./.github/actions/check-package
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: cpplint
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/check-package
 
   tests:
@@ -85,7 +85,7 @@ jobs:
         with:
           name: image
           path: /tmp/
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/run-tests
         with:
           api-token: ${{matrix.token}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
           name: image
           path: /tmp/
       - uses: actions/checkout@v3
+
+      - name: Generate license
+        run: echo '${{secrets.LICENSE_KEY}}' > lic.key
+
       - uses: ./.github/actions/run-tests
         with:
           api-token: ${{matrix.token}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
     strategy:
       matrix:
         token: [ "", "TOKEN" ]
-        reductstore_version: [ "main", "latest" ]
+        reductstore_version: [ "main" ]
+        license_file: [ "", "lic.key" ]
         include:
           - token: ""
             exclude_token_api_tag: "~[token_api]"
@@ -69,7 +70,9 @@ jobs:
           - reductstore_version: "main"
             exclude_api_version_tag: ""
           - reductstore_version: "latest"
-            exclude_api_version_tag: "~[1_8]"
+            exclude_api_version_tag: "~[1_9]"
+          - license_file: ""
+            exclude_license_tag: "~[license]"
 
     needs:
       - build
@@ -86,5 +89,6 @@ jobs:
       - uses: ./.github/actions/run-tests
         with:
           api-token: ${{matrix.token}}
-          tags: "${{matrix.exclude_token_api_tag}} ${{matrix.exclude_api_version_tag}}"
+          tags: "${{matrix.exclude_token_api_tag}} ${{matrix.exclude_api_version_tag}} ${{matrix.exclude_license_tag}}"
           reductstore-version: ${{matrix.reductstore_version}}
+          lic_file: ${{matrix.license_file}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- RS-179: add license information to ServerInfo, [PR-65](https://github.com/reductstore/reduct-cpp/pull/65)
+
 ## [1.8.0] - 2023-12-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ in C++20. It allows developers to easily interact with the database from their C
 ## Features
 
 * Written in C++20
-* Support ReductStore HTTP API v1.8
+* Support ReductStore HTTP API v1.9
 * Support HTTP and HTTPS protocols
 * Exception free
 * Support Linux AMD64

--- a/src/reduct/client.cc
+++ b/src/reduct/client.cc
@@ -45,7 +45,7 @@ class Client : public IClient {
           .defaults = {.bucket = default_bucket_settings},
       };
 
-      if (data.contains("license")) {
+      if (data.contains("license") && !data.at("license").is_null()) {
         auto& license = data.at("license");
         server_info.license = ServerInfo::License{
             .licensee = license.at("licensee"),

--- a/src/reduct/client.h
+++ b/src/reduct/client.h
@@ -35,6 +35,23 @@ class IClient {
     Time oldest_record;
     Time latest_record;
 
+    /**
+     * @brief License information
+     */
+    struct License {
+      std::string licensee;     // Licensee usually is the company name
+      std::string invoice;      // Invoice number
+      Time expiry_date;         // Expiry date of the license in ISO 8601 format (UTC)
+      std::string plan;         // Plan name
+      uint64_t device_number;   // Number of devices (0 for unlimited)
+      uint64_t disk_quota;      // Disk quota in TB (0 for unlimited)
+      std::string fingerprint;  // License fingerprint
+
+      bool operator<=>(const License&) const = default;
+    };
+
+    std::optional<License> license;  // License information
+
     struct Defaults {
       IBucket::Settings bucket;  // default settings for a new bucket
 
@@ -222,7 +239,6 @@ class IClient {
    * @return error
    */
   [[nodiscard]] virtual Error UpdateReplication(std::string_view name, ReplicationSettings settings) const noexcept = 0;
-
 
   /**
    * @brief Remove replication

--- a/src/reduct/client.h
+++ b/src/reduct/client.h
@@ -50,7 +50,7 @@ class IClient {
       bool operator<=>(const License&) const = default;
     };
 
-    std::optional<License> license;  // License information
+    std::optional<License> license;  // License information. If empty, then it is BUSL-1.1
 
     struct Defaults {
       IBucket::Settings bucket;  // default settings for a new bucket

--- a/tests/reduct/bucket_api_test.cc
+++ b/tests/reduct/bucket_api_test.cc
@@ -122,7 +122,7 @@ TEST_CASE("reduct::IBucket should get bucket stats", "[bucket_api]") {
   REQUIRE(info == IBucket::BucketInfo{
                       .name = kBucketName,
                       .entry_count = 2,
-                      .size = 80,
+                      .size = 98,
                       .oldest_record = t,
                       .latest_record = t + std::chrono::seconds(1),
                       .is_provisioned = false,
@@ -141,7 +141,7 @@ TEST_CASE("reduct::IBucket should get list of entries", "[bucket_api]") {
                             .name = "entry-1",
                             .record_count = 2,
                             .block_count = 1,
-                            .size = 78,
+                            .size = 98,
                             .oldest_record = t + s(1),
                             .latest_record = t + s(2),
                         });
@@ -150,7 +150,7 @@ TEST_CASE("reduct::IBucket should get list of entries", "[bucket_api]") {
                             .name = "entry-2",
                             .record_count = 2,
                             .block_count = 1,
-                            .size = 78,
+                            .size = 98,
                             .oldest_record = t + s(3),
                             .latest_record = t + s(4),
                         });

--- a/tests/reduct/server_api_test.cc
+++ b/tests/reduct/server_api_test.cc
@@ -22,7 +22,7 @@ TEST_CASE("reduct::Client should get info", "[server_api]") {
   REQUIRE(info.version >= "1.2.0");
 
   REQUIRE(info.bucket_count == 2);
-  REQUIRE(info.usage == 234);
+  REQUIRE(info.usage == 294);
   REQUIRE(info.uptime.count() >= 1);
   REQUIRE(info.oldest_record.time_since_epoch() == s(1));
   REQUIRE(info.latest_record.time_since_epoch() == s(6));
@@ -33,19 +33,19 @@ TEST_CASE("reduct::Client should get info", "[server_api]") {
   REQUIRE(*info.defaults.bucket.quota_size == 0);
 }
 
-TEST_CASE("reduct::Client should get info", "[server_api][license") {
+TEST_CASE("reduct::Client should get license info", "[server_api][license") {
   Fixture ctx;
   auto [info, err] = ctx.client->GetInfo();
 
   REQUIRE(err == Error::kOk);
   REQUIRE(info.license);
-  REQUIRE(info.license->licensee == "Reduct");
-  REQUIRE(info.license->invoice == "INV-2022-01");
+  REQUIRE(info.license->licensee == "ReductStore,LLC");
+  REQUIRE(info.license->invoice == "xxxxxx");
   REQUIRE(info.license->expiry_date.time_since_epoch() == s(1672531200));
-  REQUIRE(info.license->plan == "Enterprise");
-  REQUIRE(info.license->device_number == 100);
-  REQUIRE(info.license->disk_quota == 100);
-  REQUIRE(info.license->fingerprint == "fingerprint");
+  REQUIRE(info.license->plan == "UNLIMITED");
+  REQUIRE(info.license->device_number == 1);
+  REQUIRE(info.license->disk_quota == 0);
+  REQUIRE(info.license->fingerprint == "df92c95a7c9b56c2af99b290c39d8471c3e6cbf9dc33dc9bdb4116b98d465cc9");
 }
 
 TEST_CASE("reduct::Client should list buckets", "[server_api]") {
@@ -54,13 +54,13 @@ TEST_CASE("reduct::Client should list buckets", "[server_api]") {
 
   REQUIRE_FALSE(list.empty());
   REQUIRE(list[0].name == "test_bucket_1");
-  REQUIRE(list[0].size == 156);
+  REQUIRE(list[0].size == 196);
   REQUIRE(list[0].entry_count == 2);
   REQUIRE(list[0].oldest_record.time_since_epoch() == s(1));
   REQUIRE(list[0].latest_record.time_since_epoch() == s(4));
 
   REQUIRE(list[1].name == "test_bucket_2");
-  REQUIRE(list[1].size == 78);
+  REQUIRE(list[1].size == 98);
   REQUIRE(list[1].entry_count == 1);
   REQUIRE(list[1].oldest_record.time_since_epoch() == s(5));
   REQUIRE(list[1].latest_record.time_since_epoch() == s(6));

--- a/tests/reduct/server_api_test.cc
+++ b/tests/reduct/server_api_test.cc
@@ -33,7 +33,7 @@ TEST_CASE("reduct::Client should get info", "[server_api]") {
   REQUIRE(*info.defaults.bucket.quota_size == 0);
 }
 
-TEST_CASE("reduct::Client should get license info", "[server_api][license") {
+TEST_CASE("reduct::Client should get license info", "[server_api][license]") {
   Fixture ctx;
   auto [info, err] = ctx.client->GetInfo();
 
@@ -41,7 +41,7 @@ TEST_CASE("reduct::Client should get license info", "[server_api][license") {
   REQUIRE(info.license);
   REQUIRE(info.license->licensee == "ReductStore,LLC");
   REQUIRE(info.license->invoice == "xxxxxx");
-  REQUIRE(info.license->expiry_date.time_since_epoch() == s(1672531200));
+  REQUIRE(info.license->expiry_date.time_since_epoch().count() == 1672531200);
   REQUIRE(info.license->plan == "UNLIMITED");
   REQUIRE(info.license->device_number == 1);
   REQUIRE(info.license->disk_quota == 0);

--- a/tests/reduct/server_api_test.cc
+++ b/tests/reduct/server_api_test.cc
@@ -28,7 +28,7 @@ TEST_CASE("reduct::Client should get info", "[server_api]") {
   REQUIRE(info.latest_record.time_since_epoch() == s(6));
 
   REQUIRE(*info.defaults.bucket.max_block_size == 64000000);
-  // REQUIRE(*info.defaults.bucket.max_block_records == 1024); TODO: get back in 1.7
+  REQUIRE(*info.defaults.bucket.max_block_records == 256);
   REQUIRE(*info.defaults.bucket.quota_type == IBucket::QuotaType::kNone);
   REQUIRE(*info.defaults.bucket.quota_size == 0);
 }
@@ -41,7 +41,7 @@ TEST_CASE("reduct::Client should get license info", "[server_api][license]") {
   REQUIRE(info.license);
   REQUIRE(info.license->licensee == "ReductStore,LLC");
   REQUIRE(info.license->invoice == "xxxxxx");
-  REQUIRE(info.license->expiry_date.time_since_epoch().count() == 1672531200);
+  REQUIRE(info.license->expiry_date.time_since_epoch().count() == 2051222400000000000);
   REQUIRE(info.license->plan == "UNLIMITED");
   REQUIRE(info.license->device_number == 1);
   REQUIRE(info.license->disk_quota == 0);

--- a/tests/reduct/server_api_test.cc
+++ b/tests/reduct/server_api_test.cc
@@ -33,6 +33,21 @@ TEST_CASE("reduct::Client should get info", "[server_api]") {
   REQUIRE(*info.defaults.bucket.quota_size == 0);
 }
 
+TEST_CASE("reduct::Client should get info", "[server_api][license") {
+  Fixture ctx;
+  auto [info, err] = ctx.client->GetInfo();
+
+  REQUIRE(err == Error::kOk);
+  REQUIRE(info.license);
+  REQUIRE(info.license->licensee == "Reduct");
+  REQUIRE(info.license->invoice == "INV-2022-01");
+  REQUIRE(info.license->expiry_date.time_since_epoch() == s(1672531200));
+  REQUIRE(info.license->plan == "Enterprise");
+  REQUIRE(info.license->device_number == 100);
+  REQUIRE(info.license->disk_quota == 100);
+  REQUIRE(info.license->fingerprint == "fingerprint");
+}
+
 TEST_CASE("reduct::Client should list buckets", "[server_api]") {
   Fixture ctx;
   auto [list, err] = ctx.client->GetBucketList();


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Add the optional filed to `ServerInfo` structure:

```cpp
auto [info, err] = ctx.client->GetInfo();
std::cout << info.license->licensee;
```

### Related issues

### Does this PR introduce a breaking change?

No

### Other information:
