### PR TITLE
Please use std::chrono::parse instead of date::parse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(reductcpp VERSION ${REDUCT_CPP_FULL_VERSION})
 message(STATUS "Version ${REDUCT_CPP_FULL_VERSION}")
 
 set(REDUCT_CPP_ENABLE_TESTS OFF CACHE BOOL "Compile tests")
+set(REDUCT_CPP_USE_STD_CHRONO OFF CACHE BOOL "use std::chrono instead of HowardHinnant date library")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/cmake/InstallDependencies.cmake
+++ b/cmake/InstallDependencies.cmake
@@ -49,12 +49,16 @@ else ()
             URL_HASH MD5=814c5e121b29e37ee836312f0eb0328f
     )
 
-    FetchContent_Declare(
-            date
-            URL https://github.com/HowardHinnant/date/archive/refs/tags/v3.0.1.zip
-            URL_HASH MD5=cf556cc376d15055b8235b05b2fc6253)
-
-    FetchContent_MakeAvailable(fmt nlohmann_json httplib concurrentqueue date)
     add_library(dependencies INTERFACE)
-    target_link_libraries(dependencies INTERFACE fmt nlohmann_json httplib concurrentqueue date)
+    FetchContent_MakeAvailable(fmt nlohmann_json httplib concurrentqueue)
+    target_link_libraries(dependencies INTERFACE fmt nlohmann_json httplib concurrentqueue)
+
+    if(NOT REDUCT_CPP_USE_STD_CHRONO)
+        FetchContent_Declare(
+                date
+                URL https://github.com/HowardHinnant/date/archive/refs/tags/v3.0.1.zip
+                URL_HASH MD5=cf556cc376d15055b8235b05b2fc6253)
+        FetchContent_MakeAvailable(date)
+        target_link_libraries(dependencies INTERFACE date)
+    endif()
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,9 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE dependencies)
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES PUBLIC_HEADER "${PUBLIC_HEADERS}")
 target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC CPPHTTPLIB_OPENSSL_SUPPORT)
+if(REDUCT_CPP_USE_STD_CHRONO)
+        target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE REDUCT_CPP_USE_STD_CHRONO)
+endif()
 
 include(GNUInstallDirs)
 install(TARGETS ${CMAKE_PROJECT_NAME}

--- a/src/reduct/client.cc
+++ b/src/reduct/client.cc
@@ -57,7 +57,7 @@ class Client : public IClient {
             .fingerprint = license.at("fingerprint"),
         };
         std::istringstream(license.at("expiry_date").get<std::string>()) >>
-            date::parse("%FT%TZ", server_info.license->expiry_date);
+            std::chrono::parse("%FT%TZ", server_info.license->expiry_date);
       }
 
       return {
@@ -142,7 +142,7 @@ class Client : public IClient {
       token_list.reserve(json_tokens.size());
       for (const auto& token : json_tokens) {
         Time created_at;
-        std::istringstream(token.at("created_at").get<std::string>()) >> date::parse("%FT%TZ", created_at);
+        std::istringstream(token.at("created_at").get<std::string>()) >> std::chrono::parse("%FT%TZ", created_at);
 
         token_list.push_back(Token{
             .name = token.at("name"),

--- a/src/reduct/client.cc
+++ b/src/reduct/client.cc
@@ -2,7 +2,11 @@
 
 #include "reduct/client.h"
 
+#ifdef REDUCT_CPP_USE_STD_CHRONO
+#include <chrono>
+#else
 #include <date/date.h>
+#endif
 #include <fmt/core.h>
 #include <nlohmann/json.hpp>
 
@@ -56,8 +60,13 @@ class Client : public IClient {
             .disk_quota = license.at("disk_quota"),
             .fingerprint = license.at("fingerprint"),
         };
+#ifdef REDUCT_CPP_USE_STD_CHRONO
         std::istringstream(license.at("expiry_date").get<std::string>()) >>
             std::chrono::parse("%FT%TZ", server_info.license->expiry_date);
+#else
+        std::istringstream(license.at("expiry_date").get<std::string>()) >>
+            date::parse("%FT%TZ", server_info.license->expiry_date);
+#endif
       }
 
       return {
@@ -142,7 +151,11 @@ class Client : public IClient {
       token_list.reserve(json_tokens.size());
       for (const auto& token : json_tokens) {
         Time created_at;
+#ifdef REDUCT_CPP_USE_STD_CHRONO
         std::istringstream(token.at("created_at").get<std::string>()) >> std::chrono::parse("%FT%TZ", created_at);
+#else
+        std::istringstream(token.at("created_at").get<std::string>()) >> date::parse("%FT%TZ", created_at);
+#endif
 
         token_list.push_back(Token{
             .name = token.at("name"),

--- a/src/reduct/internal/serialisation.cc
+++ b/src/reduct/internal/serialisation.cc
@@ -2,7 +2,11 @@
 
 #include "reduct/internal/serialisation.h"
 
+#ifdef REDUCT_CPP_USE_STD_CHRONO
+#include <chrono>
+#else
 #include <date/date.h>
+#endif
 
 namespace reduct::internal {
 
@@ -65,7 +69,11 @@ Result<IBucket::Settings> ParseBucketSettings(const nlohmann::json& json) {
 
 Result<IClient::FullTokenInfo> ParseTokenInfo(const nlohmann::json& json) {
   IClient::Time created_at;
+#ifdef REDUCT_CPP_USE_STD_CHRONO
   std::istringstream(json.at("created_at").get<std::string>()) >> std::chrono::parse("%FT%TZ", created_at);
+#else
+  std::istringstream(json.at("created_at").get<std::string>()) >> date::parse("%FT%TZ", created_at);
+#endif
 
   return {
       IClient::FullTokenInfo{

--- a/src/reduct/internal/serialisation.cc
+++ b/src/reduct/internal/serialisation.cc
@@ -65,7 +65,7 @@ Result<IBucket::Settings> ParseBucketSettings(const nlohmann::json& json) {
 
 Result<IClient::FullTokenInfo> ParseTokenInfo(const nlohmann::json& json) {
   IClient::Time created_at;
-  std::istringstream(json.at("created_at").get<std::string>()) >> date::parse("%FT%TZ", created_at);
+  std::istringstream(json.at("created_at").get<std::string>()) >> std::chrono::parse("%FT%TZ", created_at);
 
   return {
       IClient::FullTokenInfo{


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Several compiler(gcc14, latest MSVC) don't support "date" library on C++20 or later.

<details>
<summary>
compilation errors on gcc14 in C++20.
</summary>

src/reduct/client.cc: In member function ‘virtual reduct::Result<reduct::IClient::ServerInfo> reduct::Client::GetInfo() const’:
src/reduct/client.cc:60:24: error: no matching function for call to ‘parse(const char [7], reduct::IClient::Time&)’
   60 |             date::parse("%FT%TZ", server_info.license->expiry_date);
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/reduct/client.cc:5:
include/date/date.h:8086:1: note: candidate: ‘template<class Parsable, class CharT, class Traits, class Alloc> decltype ((date::from_stream(declval<std::basic_istream<_CharT, _Traits>&>(), format.c_str(), tp), date::parse_manip<Parsable, CharT, Traits, Alloc>{format, tp})) date::parse(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, Parsable&)’
 8086 | parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp)
      | ^~~~~
include/date/date.h:8086:1: note:   template argument deduction/substitution failed:
src/reduct/client.cc:60:24: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>’ and ‘const char [7]’
   60 |             date::parse("%FT%TZ", server_info.license->expiry_date);
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/date/date.h:8097:1: note: candidate: ‘template<class Parsable, class CharT, class Traits, class Alloc> decltype ((date::from_stream(declval<std::basic_istream<_CharT, _Traits>&>(), format.c_str(), tp, (& abbrev)), date::parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, (& abbrev)})) date::parse(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, Parsable&, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&)’
 8097 | parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
      | ^~~~~
include/date/date.h:8097:1: note:   candidate expects 3 arguments, 2 provided
include/date/date.h:8109:1: note: candidate: ‘template<class Parsable, class CharT, class Traits, class Alloc> decltype ((date::from_stream(declval<std::basic_istream<_CharT, _Traits>&>(), format.c_str(), tp, declval<std::__cxx11::basic_string<_CharT, _Traits, _Alloc>*>(), (& offset)), date::parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, nullptr, (& offset)})) date::parse(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, Parsable&, std::chrono::minutes&)’
 8109 | parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
      | ^~~~~
include/date/date.h:8109:1: note:   candidate expects 3 arguments, 2 provided
include/date/date.h:8123:1: note: candidate: ‘template<class Parsable, class CharT, class Traits, class Alloc> decltype ((date::from_stream(declval<std::basic_istream<_CharT, _Traits>&>(), format.c_str(), tp, (& abbrev), (& offset)), date::parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, (& abbrev), (& offset)})) date::parse(const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, Parsable&, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, std::chrono::minutes&)’
 8123 | parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
      | ^~~~~
include/date/date.h:8123:1: note:   candidate expects 4 arguments, 2 provided
include/date/date.h:8137:1: note: candidate: ‘template<class Parsable, class CharT> decltype ((date::from_stream(declval<std::basic_istream<CharT, std::char_traits<_CharT> >&>(), format, tp), date::parse_manip<Parsable, CharT>{format, tp})) date::parse(const CharT*, Parsable&)’
 8137 | parse(const CharT* format, Parsable& tp)
      | ^~~~~
include/date/date.h:8137:1: note:   template argument deduction/substitution failed:
include/date/date.h: In substitution of ‘template<class Parsable, class CharT> decltype ((date::from_stream(declval<std::basic_istream<CharT, std::char_traits<_CharT> >&>(), format, tp), date::parse_manip<Parsable, CharT>{format, tp})) date::parse(const CharT*, Parsable&) [with Parsable = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; CharT = char]’:
src/reduct/client.cc:60:24:   required from here
   60 |             date::parse("%FT%TZ", server_info.license->expiry_date);
      |             ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/date/date.h:8138:28: error: call of overloaded ‘from_stream(std::basic_istream<char>&, const char*&, std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >&)’ is ambiguous
 8138 |     -> decltype(from_stream(std::declval<std::basic_istream<CharT>&>(), format, tp),
      |                 ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/date/date.h:8000:1: note: candidate: ‘std::basic_istream<_CharT, _Traits>& date::from_stream(std::basic_istream<_CharT, _Traits>&, const CharT*, sys_time<Duration>&, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>*, std::chrono::minutes*) [with Duration = std::chrono::duration<long int, std::ratio<1, 1000000000> >; CharT = char; Traits = std::char_traits<char>; Alloc = std::allocator<char>; sys_time<Duration> = std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >; std::chrono::minutes = std::chrono::duration<long int, std::ratio<60> >]’
 8000 | from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
      | ^~~~~~~~~~~
In file included from /usr/include/c++/14/chrono:3360,
                 from src/reduct/client.h:6,
                 from src/reduct/client.cc:3:
/usr/include/c++/14/bits/chrono_io.h:2733:5: note: candidate: ‘std::basic_istream<_CharT, _Traits>& std::chrono::from_stream(std::basic_istream<_CharT, _Traits>&, const _CharT*, sys_time<_Duration>&, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>*, minutes*) [with _CharT = char; _Traits = std::char_traits<char>; _Duration = duration<long int, std::ratio<1, 1000000000> >; _Alloc = std::allocator<char>; sys_time<_Duration> = time_point<_V2::system_clock, duration<long int, std::ratio<1, 1000000000> > >; minutes = duration<long int, std::ratio<60> >]’
 2733 |     from_stream(basic_istream<_CharT, _Traits>& __is, const _CharT* __fmt,
      |     ^~~~~~~~~~~
include/date/date.h:8147:1: note: candidate: ‘template<class Parsable, class CharT, class Traits, class Alloc> decltype ((date::from_stream(declval<std::basic_istream<_CharT, _Traits>&>(), format, tp, (& abbrev)), date::parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, (& abbrev)})) date::parse(const CharT*, Parsable&, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&)’
 8147 | parse(const CharT* format, Parsable& tp, std::basic_string<CharT, Traits, Alloc>& abbrev)
      | ^~~~~
include/date/date.h:8147:1: note:   candidate expects 3 arguments, 2 provided
include/date/date.h:8158:1: note: candidate: ‘template<class Parsable, class CharT> decltype ((date::from_stream(declval<std::basic_istream<CharT, std::char_traits<_CharT> >&>(), format, tp, declval<std::__cxx11::basic_string<_CharT, std::char_traits<_CharT>, std::allocator<_T2> >*>(), (& offset)), date::parse_manip<Parsable, CharT>{format, tp, nullptr, (& offset)})) date::parse(const CharT*, Parsable&, std::chrono::minutes&)’
 8158 | parse(const CharT* format, Parsable& tp, std::chrono::minutes& offset)
      | ^~~~~
include/date/date.h:8158:1: note:   candidate expects 3 arguments, 2 provided
include/date/date.h:8169:1: note: candidate: ‘template<class Parsable, class CharT, class Traits, class Alloc> decltype ((date::from_stream(declval<std::basic_istream<_CharT, _Traits>&>(), format, tp, (& abbrev), (& offset)), date::parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, (& abbrev), (& offset)})) date::parse(const CharT*, Parsable&, std::__cxx11::basic_string<_CharT, _Traits, _Alloc>&, std::chrono::minutes&)’
 8169 | parse(const CharT* format, Parsable& tp,
      | ^~~~~
</details>

### What was changed?

use std::chrono::parse instead of date::parse

### Related issues

nothing.

### Does this PR introduce a breaking change?

nothing.

### Other information:

nothing.

