### PR TITLE
RS-261: Add `each_n` and `each_s` query parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
             exclude_token_api_tag: ""
           - reductstore_version: "main"
             exclude_api_version_tag: ""
-#          - reductstore_version: "latest"
-#            exclude_api_version_tag: "~[1_9]"
+          - reductstore_version: "latest"
+            exclude_api_version_tag: "~[1_10]"
           - license_file: ""
             exclude_license_tag: "~[license]"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         run: find src/ -name "*.cc" -o -name "*.h"  | xargs cpplint
       - name: Check code in /tests
         run: find tests/ -name "*.cc" -o -name "*.h"  | xargs cpplint
-      - name: Check code in /exampes
+      - name: Check code in /examples
         run: find examples/ -name "*.cc" -o -name "*.h"  | xargs cpplint
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- RS-261: Support for `each_n` and `each_s` query parameters, [PR-68](https://github.com/reductstore/reduct-cpp/pull/68)
+
 ### Fixed
 
 - Windows compilation, [PR-66](https://github.com/reductstore/reduct-cpp/pull/66)

--- a/src/reduct/bucket.cc
+++ b/src/reduct/bucket.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Alexey Timin
+// Copyright 2022-2024 Alexey Timin
 
 #include "reduct/bucket.h"
 #define FMT_HEADER_ONLY 1
@@ -258,7 +258,7 @@ class Bucket : public IBucket {
     }
 
     while (true) {
-      bool batched = client_->api_version() >= "1.5";
+      bool batched = internal::IsCompatible("1.5", client_->api_version());
       auto [stopped, record_err] =
           ReadRecord(fmt::format("{}/{}{}?q={}", path_, entry_name, batched ? "/batch" : "", id), batched,
                      options.head_only, callback);

--- a/src/reduct/bucket.cc
+++ b/src/reduct/bucket.cc
@@ -246,11 +246,15 @@ class Bucket : public IBucket {
 
 
     if (options.ttl) {
-      url += fmt::format("ttl={}&", options.ttl->count());
+      url += fmt::format("ttl={}&", options.ttl->count() / 1000);
     }
 
     if (options.continuous) {
       url += "continuous=true&";
+    }
+
+    if (options.head_only) {
+      url += "head=true&";
     }
 
     auto [body, err] = client_->Get(url);

--- a/src/reduct/bucket.cc
+++ b/src/reduct/bucket.cc
@@ -224,24 +224,33 @@ class Bucket : public IBucket {
       url += fmt::format("stop={}&", ToMicroseconds(*stop));
     }
 
-    if (options.ttl) {
-      url += fmt::format("ttl={}&", options.ttl->count());
-    }
-
-    if (options.continuous) {
-      url += "continuous=true&";
-    }
-
-    if (options.limit) {
-      url += fmt::format("limit={}&", *options.limit);
-    }
-
     for (const auto& [key, value] : options.include) {
       url += fmt::format("&include-{}={}", key, value);
     }
 
     for (const auto& [key, value] : options.exclude) {
       url += fmt::format("&exclude-{}={}", key, value);
+    }
+
+    if (options.each_s) {
+      url += fmt::format("each_s={}&", *options.each_s);
+    }
+
+    if (options.each_n) {
+      url += fmt::format("each_n={}&", *options.each_n);
+    }
+
+    if (options.limit) {
+      url += fmt::format("limit={}&", *options.limit);
+    }
+
+
+    if (options.ttl) {
+      url += fmt::format("ttl={}&", options.ttl->count());
+    }
+
+    if (options.continuous) {
+      url += "continuous=true&";
     }
 
     auto [body, err] = client_->Get(url);

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -252,13 +252,17 @@ class IBucket {
    * Query options
    */
   struct QueryOptions {
-    std::optional<std::chrono::milliseconds> ttl;  ///< time to live
     LabelMap include;                              ///< include labels
     LabelMap exclude;                              ///< exclude labels
+    std::optional<double> each_s;                  ///< return one record each S seconds
+    std::optional<size_t>  each_n;                 ///< return each N-th record
+    std::optional<size_t> limit;                   ///< limit number of records
+
+    std::optional<std::chrono::milliseconds> ttl;  ///< time to live
+
     bool continuous;  ///< continuous query. If true, the method returns the latest record and waits for the next one
     std::chrono::milliseconds poll_interval;  ///< poll interval for continuous query
     bool head_only;                           ///< read only metadata
-    std::optional<size_t> limit;              ///< limit number of records
   };
 
   /**

--- a/src/reduct/internal/http_client.cc
+++ b/src/reduct/internal/http_client.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Alexey Timin
+// Copyright 2022-2024 Alexey Timin
 
 #include "reduct/internal/http_client.h"
 #undef CPPHTTPLIB_BROTLI_SUPPORT
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <string>
 
 namespace reduct::internal {
 
@@ -175,5 +176,34 @@ class HttpClient : public IHttpClient {
 
 std::unique_ptr<IHttpClient> IHttpClient::Build(std::string_view url, const HttpOptions& options) {
   return std::make_unique<HttpClient>(url, options);
+}
+
+bool IsCompatible(std::string_view min, std::string_view version) {
+  if (version.empty()) {
+    return false;
+  }
+
+  auto parse_version = [](std::string version) {
+    std::stringstream ss(version);
+    std::string item;
+    std::vector<int> result;
+    while (std::getline(ss, item, '.')) {
+      result.push_back(std::stoi(item));
+    }
+    return result;
+  };
+
+  auto min_version = parse_version(std::string(min));
+  auto current_version = parse_version(std::string(version));
+
+  if (min_version.size() != current_version.size()) {
+    return false;
+  }
+
+  if (min_version.size() != 2) {
+    return false;
+  }
+
+  return min_version[0] == current_version[0] && min_version[1] <= current_version[1];
 }
 }  // namespace reduct::internal

--- a/src/reduct/internal/http_client.h
+++ b/src/reduct/internal/http_client.h
@@ -47,5 +47,7 @@ class IHttpClient {
   static std::unique_ptr<IHttpClient> Build(std::string_view url, const HttpOptions &options);
 };
 
+bool IsCompatible(std::string_view min, std::string_view version);
+
 }  // namespace reduct::internal
 #endif  // REDUCT_CPP_HTTP_CLIENT_H


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

Added support for new `each_n` and `each_s` query parameters.

### Related issues

reductstore/reductstore#465

### Does this PR introduce a breaking change?

No

### Other information:
