### PR TITLE
Add is_provisioned flag to Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - RS-261: Support for `each_n` and `each_s` query parameters, [PR-68](https://github.com/reductstore/reduct-cpp/pull/68)
+- `is_provisioned` flag to Token, [PR-69](https://github.com/reductstore/reduct-cpp/pull/69)
 
 ### Fixed
 

--- a/src/reduct/client.cc
+++ b/src/reduct/client.cc
@@ -147,6 +147,7 @@ class Client : public IClient {
         token_list.push_back(Token{
             .name = token.at("name"),
             .created_at = created_at,
+            .is_provisioned = token.at("is_provisioned"),
         });
       }
     } catch (const std::exception& e) {

--- a/src/reduct/client.h
+++ b/src/reduct/client.h
@@ -105,6 +105,8 @@ class IClient {
   struct Token {
     std::string name;  // name of token
     Time created_at;   // creation time
+    bool is_provisioned;  // true if token is provisioned, you can't remove it or change its permissions
+
 
     auto operator<=>(const IClient::Token&) const = default;
   };

--- a/tests/reduct/token_api_test.cc
+++ b/tests/reduct/token_api_test.cc
@@ -19,6 +19,7 @@ TEST_CASE("reduct::Client should get token list", "[token_api]") {
   REQUIRE(tokens.size() == 1);
   REQUIRE(tokens[0].name == "init-token");
   REQUIRE(tokens[0].created_at.time_since_epoch().count() > 0);
+  REQUIRE_FALSE(tokens[0].is_provisioned);
 }
 
 TEST_CASE("reduct::Client should create token", "[token_api]") {


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

I'd forgotten to add the flag to the `Token' structure.  Now it is available in the token listing.

### Related issues

No

### Does this PR introduce a breaking change?

No

### Other information:
