### PR TITLE
RS-388: Add IBucket::RenameEntry name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RS-418: `IBucket::RemoveRecord`, `IBucket::RemoveRecordBatch`, `IBucket::RemoveQuery` methods for removing records, [PR-74](https://github.com/reductstore/reduct-cpp/pull/74)
 - RS-389: Support `QuotaType::kHard`, [PR-75](https://github.com/reductstore/reduct-cpp/pull/75)
+- RS-388: `IBucket::RenameEntry` to rename entry in bucket, [PR-76](https://github.com/reductstore/reduct-cpp/pull/76)
 
 ## [1.11.0] - 2022-08-19
 

--- a/src/reduct/bucket.cc
+++ b/src/reduct/bucket.cc
@@ -246,6 +246,12 @@ class Bucket : public IBucket {
     }
   }
 
+  Error RenameEntry(std::string_view old_name, std::string_view new_name) const noexcept override {
+        nlohmann::json data;
+        data["new_name"] = new_name;
+        return client_->Put(fmt::format("{}/{}/rename", path_, old_name), data.dump());
+  }
+
  private:
   std::string BuildQueryUrl(const std::optional<Time>& start, const std::optional<Time>& stop,
                             std::string_view entry_name, const QueryOptions& options) const {

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -382,6 +382,15 @@ class IBucket {
   virtual Result<uint64_t> RemoveQuery(std::string_view entry_name, std::optional<Time> start, std::optional<Time> stop,
                                        QueryOptions options) const noexcept = 0;
 
+
+  /**
+   * @brief Rename an entry
+   * @param old_name entry name to rename
+   * @param new_name
+   * @return
+   */
+  virtual Error RenameEntry(std::string_view old_name, std::string_view new_name) const noexcept = 0;
+
   /**
    * @brief Creates a new bucket
    * @param server_url HTTP url


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The `Bucket::RenameEntry` method was added.


### Related issues

https://github.com/reductstore/reductstore/pull/596

### Does this PR introduce a breaking change?

No

### Other information:
