### PR TITLE
RS-419: Add IBucket::Rename method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RS-418: `IBucket::RemoveRecord`, `IBucket::RemoveRecordBatch`, `IBucket::RemoveQuery` methods for removing records, [PR-74](https://github.com/reductstore/reduct-cpp/pull/74)
 - RS-389: Support `QuotaType::kHard`, [PR-75](https://github.com/reductstore/reduct-cpp/pull/75)
 - RS-388: `IBucket::RenameEntry` to rename entry in bucket, [PR-76](https://github.com/reductstore/reduct-cpp/pull/76)
+- RS-419: Add IBucket::Rename method to rename bucket, [PR-77](https://github.com/reductstore/reduct-cpp/pull/77)
 
 ## [1.11.0] - 2022-08-19
 

--- a/src/reduct/bucket.cc
+++ b/src/reduct/bucket.cc
@@ -190,7 +190,7 @@ class Bucket : public IBucket {
 
   Error Query(std::string_view entry_name, std::optional<Time> start, std::optional<Time> stop, QueryOptions options,
               ReadRecordCallback callback) const noexcept override {
-    std::string url =  BuildQueryUrl(start, stop, entry_name, options);
+    std::string url = BuildQueryUrl(start, stop, entry_name, options);
     auto [body, err] = client_->Get(url);
     if (err) {
       return err;
@@ -232,7 +232,7 @@ class Bucket : public IBucket {
 
   Result<uint64_t> RemoveQuery(std::string_view entry_name, std::optional<Time> start, std::optional<Time> stop,
                                QueryOptions options) const noexcept override {
-    std::string url =  BuildQueryUrl(start, stop, entry_name, options);
+    std::string url = BuildQueryUrl(start, stop, entry_name, options);
     auto [resp, err] = client_->Delete(url);
     if (err) {
       return {0, std::move(err)};
@@ -247,9 +247,20 @@ class Bucket : public IBucket {
   }
 
   Error RenameEntry(std::string_view old_name, std::string_view new_name) const noexcept override {
-        nlohmann::json data;
-        data["new_name"] = new_name;
-        return client_->Put(fmt::format("{}/{}/rename", path_, old_name), data.dump());
+    nlohmann::json data;
+    data["new_name"] = new_name;
+    return client_->Put(fmt::format("{}/{}/rename", path_, old_name), data.dump());
+  }
+
+  Error Rename(std::string_view new_name) noexcept override {
+    nlohmann::json data;
+    data["new_name"] = new_name;
+    auto err = client_->Put(fmt::format("{}/rename", path_), data.dump());
+    if (err) {
+      return err;
+    }
+    path_ = fmt::format("/b/{}", new_name);
+    return Error::kOk;
   }
 
  private:

--- a/src/reduct/bucket.h
+++ b/src/reduct/bucket.h
@@ -392,6 +392,13 @@ class IBucket {
   virtual Error RenameEntry(std::string_view old_name, std::string_view new_name) const noexcept = 0;
 
   /**
+   * @brief Rename the bucket
+   * @param new_name
+   * @return
+   */
+  virtual Error Rename(std::string_view new_name) noexcept = 0;
+
+  /**
    * @brief Creates a new bucket
    * @param server_url HTTP url
    * @param name name of the bucket

--- a/tests/reduct/bucket_api_test.cc
+++ b/tests/reduct/bucket_api_test.cc
@@ -192,3 +192,14 @@ TEST_CASE("reduct::IBucket should remove entry", "[bucket_api][1_6]") {
   REQUIRE(bucket->RemoveEntry("entry-1") ==
           Error{.code = 404, .message = fmt::format("Entry 'entry-1' not found in bucket '{}'", kBucketName)});
 }
+
+TEST_CASE("reduct::IBucket should rename bucket", "[bucket_api][1_12]") {
+  Fixture ctx;
+  auto [bucket, _] = ctx.client->CreateBucket(kBucketName);
+  auto err =  bucket->Rename("test_bucket_new");
+  REQUIRE(err == Error::kOk);
+  REQUIRE(bucket->GetInfo().result.name == "test_bucket_new");
+
+  auto [bucket_old, get_err] = ctx.client->GetBucket(kBucketName);
+  REQUIRE(get_err == Error{.code = 404, .message = fmt::format("Bucket '{}' is not found", kBucketName)});
+}


### PR DESCRIPTION
Closes #

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature

### What was changed?

The `IBucket::Rename` method was added.

### Related issues

https://github.com/reductstore/reductstore/pull/597

### Does this PR introduce a breaking change?

No

### Other information:
