### PR TITLE
Harden GitHub Actions token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: ci
+permissions: read-all
 on:
   push:
     branches: [ main ]
@@ -24,6 +25,9 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     needs: cpplint
+    permissions:
+      contents: read
+      actions: write
     strategy:
       matrix:
         os: [ ubuntu-24.04, windows-2022 ]


### PR DESCRIPTION
Closes #121

### Please check if the PR fulfills these requirements

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security hardening / CI configuration update.

### What was changed?

- Set workflow-level default `GITHUB_TOKEN` permissions to `read-all` in `.github/workflows/ci.yml`.
- Scoped elevated permissions only to the `build` job that uploads artifacts:
  - `contents: read`
  - `actions: write`
- Kept all other jobs on read-only token permissions by default.

This implements the approved plan on issue #121 (plan comment: https://github.com/reductstore/reduct-cpp/issues/121#issuecomment-4313423329).

### Related issues

- https://github.com/reductstore/reduct-cpp/issues/121
- Parent tracker: https://github.com/reductstore/security/issues/16

### Does this PR introduce a breaking change?

No.

### Other information:

Validation performed:
- `python3` YAML parse check for `.github/workflows/ci.yml` (syntax OK).
