### PR TITLE
Pin GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build cpplint image
         run: pip install "cpplint<2"
       - name: Check code in /src
@@ -36,7 +36,7 @@ jobs:
           - os: windows-2022
             package_manager: vcpkg
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload test artifacts
         if: matrix.package_manager == 'conan'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reduct-tests
           path: build/Release/bin/reduct-tests
@@ -80,9 +80,9 @@ jobs:
             audit_enabled: "false"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download test artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: reduct-tests
           path: build/Release/bin/
@@ -106,7 +106,7 @@ jobs:
         dependency: [ system, fetchcontent ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -136,7 +136,7 @@ jobs:
     runs-on: windows-2022
     needs: unit-tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -162,7 +162,7 @@ jobs:
       matrix:
         os: [ ubuntu-24.04, windows-2022 ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create conan package
         uses: ./.github/actions/install-conan


### PR DESCRIPTION
Closes #123

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Security/CI hardening

### What was changed?

- Pinned `actions/checkout` to commit `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`) in all workflow jobs.
- Updated and pinned `actions/upload-artifact` to `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (`v7.0.1`).
- Updated and pinned `actions/download-artifact` to `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (`v8.0.1`).
- Left local composite actions (`./.github/actions/*`) unchanged.

### Related issues

- https://github.com/reductstore/reduct-cpp/issues/123
- https://github.com/reductstore/security/issues/22
- Plan comment: https://github.com/reductstore/reduct-cpp/issues/123#issuecomment-4388013355

### Does this PR introduce a breaking change?

No API/runtime breaking change for the C++ SDK; workflow action major versions were advanced and pinned, with behavior validated by CI.

### Other information:

- Validation: workflow references were audited and all `actions/*` refs in `.github/workflows/ci.yml` are now immutable SHAs.
