### PR TITLE
Add replication destination prefix support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add replication destination prefix support, [PR-NNN](https://github.com/reductstore/reduct-cpp/pull/NNN)
+
 ## 1.20.0 - 2026-06-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add replication destination prefix support, [PR-NNN](https://github.com/reductstore/reduct-cpp/pull/NNN)
+- Add replication destination prefix support, [PR-135](https://github.com/reductstore/reduct-cpp/pull/135)
 
 ## 1.20.0 - 2026-06-16
 

--- a/src/reduct/client.h
+++ b/src/reduct/client.h
@@ -222,6 +222,7 @@ class IClient {
     std::string dst_bucket;                // Destination bucket
     std::string dst_host;                  // Destination host URL (e.g. https://reductstore.com)
     std::optional<std::string> dst_token;  // Destination access token
+    std::string dst_prefix;                // Prefix to add to destination entry names
     std::vector<std::string>
         entries;  // Entries to replicate. If empty, all entries are replicated. Wildcards are supported.
     std::optional<std::string> when;                   // Replication condition

--- a/src/reduct/internal/serialisation.cc
+++ b/src/reduct/internal/serialisation.cc
@@ -237,6 +237,9 @@ Result<nlohmann::json> ReplicationSettingsToJsonString(IClient::ReplicationSetti
     if (settings.dst_token) {
       json_data["dst_token"] = *settings.dst_token;
     }
+    if (!settings.dst_prefix.empty()) {
+      json_data["dst_prefix"] = settings.dst_prefix;
+    }
     json_data["entries"] = settings.entries;
     json_data["mode"] = ReplicationModeToString(settings.mode);
 
@@ -278,6 +281,10 @@ Result<IClient::FullReplicationInfo> ParseFullReplicationInfo(const nlohmann::js
 
     if (settings.contains("dst_token") && !settings.at("dst_token").is_null()) {
       info.settings.dst_token = settings.at("dst_token");
+    }
+
+    if (settings.contains("dst_prefix") && !settings.at("dst_prefix").is_null()) {
+      info.settings.dst_prefix = settings.at("dst_prefix");
     }
 
     if (settings.contains("when") && !settings.at("when").is_null()) {

--- a/tests/reduct/replication_api_test.cc
+++ b/tests/reduct/replication_api_test.cc
@@ -6,6 +6,7 @@
 
 #include "fixture.h"
 #include "reduct/client.h"
+#include "reduct/internal/serialisation.h"
 
 using reduct::Error;
 using reduct::IClient;
@@ -76,6 +77,81 @@ TEST_CASE("reduct::Client should update a replication", "[replication_api][1_17]
     REQUIRE(ctx.client->UpdateReplication("test_replication_2", {}) ==
             Error{404, "Replication 'test_replication_2' does not exist"});
   }
+}
+
+TEST_CASE("reduct::Client should serialize replication destination prefix", "[replication_api]") {
+  auto settings = DefaultSettings();
+
+  SECTION("omits empty destination prefix") {
+    auto [json, err] = reduct::internal::ReplicationSettingsToJsonString(settings);
+
+    REQUIRE(err == Error::kOk);
+    REQUIRE_FALSE(json.contains("dst_prefix"));
+  }
+
+  SECTION("serializes non-empty destination prefix") {
+    settings.dst_prefix = "robot-1";
+
+    auto [json, err] = reduct::internal::ReplicationSettingsToJsonString(settings);
+
+    REQUIRE(err == Error::kOk);
+    REQUIRE(json.at("dst_prefix") == "robot-1");
+  }
+}
+
+TEST_CASE("reduct::Client should parse replication destination prefix", "[replication_api]") {
+  auto response = nlohmann::json{
+      {"info",
+       {{"name", "test_replication"},
+        {"mode", "enabled"},
+        {"is_active", true},
+        {"is_provisioned", false},
+        {"pending_records", 0}}},
+      {"settings",
+       {{"src_bucket", "test_bucket_1"},
+        {"dst_bucket", "test_bucket_2"},
+        {"dst_host", "http://127.0.0.1:8383"},
+        {"entries", {"entry-1"}},
+        {"mode", "enabled"}}},
+      {"diagnostics", {{"hourly", {{"ok", 0}, {"errored", 0}, {"errors", nlohmann::json::object()}}}}},
+  };
+
+  SECTION("keeps destination prefix empty when absent") {
+    auto [replication, err] = reduct::internal::ParseFullReplicationInfo(response);
+
+    REQUIRE(err == Error::kOk);
+    REQUIRE(replication.settings.dst_prefix.empty());
+  }
+
+  SECTION("parses returned destination prefix") {
+    response["settings"]["dst_prefix"] = "robot-1";
+
+    auto [replication, err] = reduct::internal::ParseFullReplicationInfo(response);
+
+    REQUIRE(err == Error::kOk);
+    REQUIRE(replication.settings.dst_prefix == "robot-1");
+  }
+}
+
+TEST_CASE("reduct::Client should set replication destination prefix", "[replication_api][1_20]") {
+  Fixture ctx;
+  auto settings = DefaultSettings();
+  settings.dst_prefix = "robot-1";
+
+  auto err = ctx.client->CreateReplication("test_replication", settings);
+  REQUIRE(err == Error::kOk);
+
+  auto [replication, err_2] = ctx.client->GetReplication("test_replication");
+  REQUIRE(err_2 == Error::kOk);
+  REQUIRE(replication.settings.dst_prefix == "robot-1");
+
+  settings.dst_prefix = "line-a";
+  err = ctx.client->UpdateReplication("test_replication", settings);
+  REQUIRE(err == Error::kOk);
+
+  auto [updated_replication, err_3] = ctx.client->GetReplication("test_replication");
+  REQUIRE(err_3 == Error::kOk);
+  REQUIRE(updated_replication.settings.dst_prefix == "line-a");
 }
 
 TEST_CASE("reduct::Client should set replication mode", "[replication_api][1_18]") {

--- a/tests/reduct/token_api_test.cc
+++ b/tests/reduct/token_api_test.cc
@@ -35,7 +35,8 @@ TEST_CASE("reduct::Client should create token", "[token_api]") {
   REQUIRE(token.starts_with("test_token-"));
 
   SECTION("Conflict") {
-    REQUIRE(ctx.client->CreateToken(kTestTokenName, IClient::Permissions{}).error == Error{409, "Token 'test_token' already exists"});
+    REQUIRE(ctx.client->CreateToken(kTestTokenName, IClient::Permissions{}).error ==
+            Error{409, "Token 'test_token' already exists"});
   }
 }
 


### PR DESCRIPTION
Closes #134

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Added `IClient::ReplicationSettings::dst_prefix` for destination entry prefix configuration.
- Serialized non-empty `dst_prefix` in replication create/update payloads while omitting the default empty value for backward compatibility.
- Parsed returned `settings.dst_prefix` from full replication details, defaulting to an empty string for older responses.
- Added serialization/parser coverage and a live create/update/get round-trip test tagged `[1_20]`.
- Wrapped an existing long token API assertion so the repository cpplint command passes on current `main`.

### Related issues

- Issue: https://github.com/reductstore/reduct-cpp/issues/134
- Plan: https://github.com/reductstore/reduct-cpp/issues/134#issuecomment-4902878480
- Core implementation: https://github.com/reductstore/reductstore/pull/1486

### Does this PR introduce a breaking change?

No. The public settings struct change is additive, empty `dst_prefix` is omitted from request payloads, and older server responses without the field still deserialize with an empty prefix.

### Other information:

Local validation:

- `.venv/bin/cpplint` over `src/`, `tests/`, and `examples/`
- `cmake -S . -B build -DREDUCT_CPP_USE_FETCHCONTENT=ON -DREDUCT_CPP_ENABLE_TESTS=ON`
- `cmake --build build`
- `REDUCT_CPP_TOKEN_API=TOKEN ./build/bin/reduct-tests` against `reduct/store:main`
- `REDUCT_CPP_TOKEN_API=TOKEN ./build/bin/reduct-tests "~[1_20]"` against `reduct/store:latest`
