### PR TITLE
Add lifecycle processing_interval support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,9 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        token: [ "", "TOKEN" ]
+        token: [ "TOKEN" ]
         reductstore_version: [ "main", "latest" ]
         include:
-          - token: ""
-            exclude_token_api_tag: "~[token_api]"
           - token: "TOKEN"
             exclude_token_api_tag: ""
           - reductstore_version: "main"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add lifecycle `processing_interval` setting support.
 - Add replication compression setting support, [PR-137](https://github.com/reductstore/reduct-cpp/pull/137)
 - Add replication destination prefix support, [PR-135](https://github.com/reductstore/reduct-cpp/pull/135)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add lifecycle `processing_interval` setting support.
+- Add lifecycle `processing_interval` setting support, [PR-139](https://github.com/reductstore/reduct-cpp/pull/139)
 - Add replication compression setting support, [PR-137](https://github.com/reductstore/reduct-cpp/pull/137)
 - Add replication destination prefix support, [PR-135](https://github.com/reductstore/reduct-cpp/pull/135)
 

--- a/src/reduct/client.h
+++ b/src/reduct/client.h
@@ -318,6 +318,7 @@ class IClient {
     std::optional<std::string> interval;           // Interval between lifecycle runs
     std::optional<std::string> when;               // Lifecycle condition
     LifecycleMode mode = LifecycleMode::kEnabled;  // Lifecycle mode
+    std::optional<std::string> processing_interval;  // Data time window to process in one lifecycle run
 
     auto operator<=>(const LifecycleSettings&) const = default;
   };

--- a/src/reduct/internal/serialisation.cc
+++ b/src/reduct/internal/serialisation.cc
@@ -388,6 +388,9 @@ Result<nlohmann::json> LifecycleSettingsToJsonString(IClient::LifecycleSettings 
       json_data["interval"] = *settings.interval;
     }
     json_data["mode"] = LifecycleModeToString(settings.mode);
+    if (settings.processing_interval) {
+      json_data["processing_interval"] = *settings.processing_interval;
+    }
 
     if (settings.when) {
       try {
@@ -436,6 +439,10 @@ Result<IClient::FullLifecycleInfo> ParseFullLifecycleInfo(const nlohmann::json& 
 
     if (settings.contains("when") && !settings.at("when").is_null()) {
       info.settings.when = settings.at("when").dump();
+    }
+
+    if (settings.contains("processing_interval") && !settings.at("processing_interval").is_null()) {
+      info.settings.processing_interval = settings.at("processing_interval");
     }
   } catch (const std::exception& ex) {
     return {{}, Error{.code = -1, .message = ex.what()}};

--- a/tests/reduct/lifecycle_api_test.cc
+++ b/tests/reduct/lifecycle_api_test.cc
@@ -149,6 +149,50 @@ TEST_CASE("reduct::Client should set lifecycle when condition", "[lifecycle_api]
   REQUIRE(lifecycle.settings.when == settings.when);
 }
 
+TEST_CASE("reduct::Client should set lifecycle processing interval", "[lifecycle_api][1_21]") {
+  Fixture ctx;
+  auto settings = DefaultSettings();
+  settings.processing_interval = "6h";
+
+  auto err = ctx.client->CreateLifecycle("test_lifecycle", settings);
+  REQUIRE(err == Error::kOk);
+
+  auto [lifecycle, err_2] = ctx.client->GetLifecycle("test_lifecycle");
+  REQUIRE(err_2 == Error::kOk);
+  REQUIRE(lifecycle.settings == settings);
+
+  settings.processing_interval = "12h";
+  err = ctx.client->UpdateLifecycle("test_lifecycle", settings);
+  REQUIRE(err == Error::kOk);
+
+  auto [updated_lifecycle, err_3] = ctx.client->GetLifecycle("test_lifecycle");
+  REQUIRE(err_3 == Error::kOk);
+  REQUIRE(updated_lifecycle.settings == settings);
+
+  settings.type = IClient::LifecycleType::kCompress;
+  settings.processing_interval = "1d";
+  err = ctx.client->CreateLifecycle("test_lifecycle_compress", settings);
+  REQUIRE(err == Error::kOk);
+
+  auto [compress_lifecycle, err_4] = ctx.client->GetLifecycle("test_lifecycle_compress");
+  REQUIRE(err_4 == Error::kOk);
+  REQUIRE(compress_lifecycle.settings == settings);
+}
+
+TEST_CASE("reduct::internal::LifecycleSettingsToJsonString should support processing interval",
+          "[lifecycle_api][unit]") {
+  auto settings = DefaultSettings();
+
+  auto [json_data, err] = reduct::internal::LifecycleSettingsToJsonString(settings);
+  REQUIRE(err == Error::kOk);
+  REQUIRE_FALSE(json_data.contains("processing_interval"));
+
+  settings.processing_interval = "6h";
+  auto [json_data_with_processing_interval, err_2] = reduct::internal::LifecycleSettingsToJsonString(settings);
+  REQUIRE(err_2 == Error::kOk);
+  REQUIRE(json_data_with_processing_interval.at("processing_interval") == "6h");
+}
+
 TEST_CASE("reduct::Client should parse lifecycle type and RFC3339 last_run", "[lifecycle_api][unit]") {
   auto lifecycle_list_json = nlohmann::json::parse(R"({
     "lifecycles": [
@@ -197,4 +241,17 @@ TEST_CASE("reduct::Client should parse lifecycle type and RFC3339 last_run", "[l
               full_lifecycle.info.last_run->time_since_epoch())
               .count() %
               1000000 == 654321);
+  REQUIRE_FALSE(full_lifecycle.settings.processing_interval.has_value());
+
+  full_lifecycle_json["settings"]["processing_interval"] = "12h";
+  auto [full_lifecycle_with_processing_interval, full_err_2] =
+      reduct::internal::ParseFullLifecycleInfo(full_lifecycle_json);
+  REQUIRE(full_err_2 == Error::kOk);
+  REQUIRE(full_lifecycle_with_processing_interval.settings.processing_interval == "12h");
+
+  full_lifecycle_json["settings"]["processing_interval"] = nullptr;
+  auto [full_lifecycle_with_null_processing_interval, full_err_3] =
+      reduct::internal::ParseFullLifecycleInfo(full_lifecycle_json);
+  REQUIRE(full_err_3 == Error::kOk);
+  REQUIRE_FALSE(full_lifecycle_with_null_processing_interval.settings.processing_interval.has_value());
 }


### PR DESCRIPTION
Closes #138

### Please check if the PR fulfills these requirements

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) - changelog only, per repo guidance
- [x] CHANGELOG.md has been updated (for bug fixes / features / docs)

### What kind of change does this PR introduce?

Feature.

### What was changed?

- Added optional `processing_interval` to `IClient::LifecycleSettings`.
- Serialize `processing_interval` in lifecycle create/update payloads when set.
- Parse `processing_interval` from full lifecycle settings when returned by the server, preserving `std::nullopt` when absent or null.
- Added lifecycle tests for:
  - JSON serialization omission/presence;
  - full lifecycle parsing for present, absent, and null values;
  - create/update/get round-trip against `reduct/store:main` for delete policies;
  - create/get round-trip against `reduct/store:main` for compress policies.
- Added an unreleased changelog entry.

Plan approval: https://github.com/reductstore/reduct-cpp/issues/138#issuecomment-5239641772

### Related issues

- https://github.com/reductstore/reduct-cpp/issues/138
- Parent: https://github.com/reductstore/reductstore/issues/1577
- Core implementation: https://github.com/reductstore/reductstore/pull/1549

### Does this PR introduce a breaking change?

No. Omitting `processing_interval` keeps the request payload unchanged and parses older server responses as `std::nullopt`.

### Other information:

Local validation:

- `find src/ \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 cpplint`
- `find tests/ \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 cpplint`
- `find examples/ \( -name "*.cc" -o -name "*.h" \) -print0 | xargs -0 cpplint`
- `cmake -S . -B build -DREDUCT_CPP_USE_FETCHCONTENT=ON -DREDUCT_CPP_ENABLE_TESTS=ON`
- `cmake --build build`
- `REDUCT_CPP_TOKEN_API=TOKEN ./build/bin/reduct-tests` against refreshed `reduct/store:main`
- `REDUCT_CPP_TOKEN_API=TOKEN ./build/bin/reduct-tests "~[1_21]"` against refreshed `reduct/store:latest`

Host note:

- Initial `pip install "cpplint<2"` was blocked by the host's externally managed Python policy, but `cpplint` was already installed and all cpplint checks passed.
- The local `reduct/store:main` image was stale and did not return `processing_interval`; after `docker pull reduct/store:main`, the refreshed image returned the field and the full main-image suite passed.
